### PR TITLE
exclusion for hadoop-client-api

### DIFF
--- a/batch-models/pom.xml
+++ b/batch-models/pom.xml
@@ -81,6 +81,14 @@
 					<groupId>org.apache.hadoop</groupId>
 					<artifactId>hadoop-client</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.hadoop</groupId>
+					<artifactId>hadoop-client-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.hadoop</groupId>
+					<artifactId>hadoop-client-runtime</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
added exclusion for spark core 3.2.1